### PR TITLE
Update requireent.txt and dockerfile for latest python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 
 COPY requirements.txt /app/
-RUN pip install --no-cache-dir -r requirements.txt || tru
+RUN pip install --no-cache-dir -r requirements.txt || true
 
 COPY src/ /app/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,17 @@
-FROM python:3.8.0-alpine3.10
-# Python docker images: https://github.com/docker-library/docs/tree/master/python/
 
-USER root
+FROM python:3.8.0-alpine
 
-# Copy the src
 WORKDIR /app
-COPY src/ /app/src/
-COPY ./requirements.txt /app
-RUN ls -la /app
 
-# Install python dependencies
-RUN python3 --version
-RUN pip3 install --upgrade pip
-RUN pip3 install --no-cache-dir -r /app/requirements.txt
-RUN pip3 list --format=columns
 
-USER 1001
 
-# EXPOSE 5001
-ENTRYPOINT ["python3", "/app/src/app.py"]
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt || tru
+
+COPY src/ /app/
+
+
+
+EXPOSE 5001
+
+CMD ["python", "app.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,12 @@
 # Install Instructions:
 # pip3 install -r requirements.txt
 
-flask==1.1.1
+
+# requirements.txt
+Flask==2.3.3
+# Optional: pin core deps to compatible versions (helps reproducibility)
+Jinja2==3.1.4
+Werkzeug==2.3.7
+itsdangerous==2.1.2
+click==8.1.7
 


### PR DESCRIPTION
Before
requirement.txt contains only "flask==1.1.1."

After
Flask==2.3.3

Optional: pin core deps to compatible versions (helps reproducibility)
Jinja2==3.1.4
Werkzeug==2.3.7
itsdangerous==2.1.2
click==8.1.7

Note: Flask version change in lastest python.

Simplify the Dockerfile as well, since we don't need to follow such long steps.